### PR TITLE
chore: add Supabase keep-alive workflow and RLS migration

### DIFF
--- a/.github/workflows/keep-supabase-alive.yml
+++ b/.github/workflows/keep-supabase-alive.yml
@@ -1,0 +1,29 @@
+name: Keep Supabase Alive
+
+# Prevents the Supabase free-tier project from auto-pausing after ~7 days of
+# inactivity by running a tiny query against the database on a schedule.
+
+on:
+  schedule:
+    # Runs every day at 06:00 UTC. GitHub may delay scheduled runs by a few
+    # minutes during peak load, so a daily cadence keeps a safe margin under
+    # the ~7-day inactivity window.
+    - cron: "0 6 * * *"
+  # Allows manual trigger from the Actions tab for testing.
+  workflow_dispatch:
+
+jobs:
+  ping:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Ping Supabase database
+        env:
+          # Add this in: GitHub repo > Settings > Secrets and variables >
+          # Actions > New repository secret (name: SUPABASE_DB_URL).
+          # Use the value of DIRECT_URL from your .env (port 5432) and append
+          # ?sslmode=require to the end, e.g.:
+          #   postgresql://postgres.xxxx:PASSWORD@aws-1-ap-southeast-1.pooler.supabase.com:5432/postgres?sslmode=require
+          # Do NOT use DATABASE_URL (port 6543 / pgbouncer=true) -- psql can't parse it.
+          SUPABASE_DB_URL: ${{ secrets.SUPABASE_DB_URL }}
+        run: |
+          psql "$SUPABASE_DB_URL" -c "SELECT 1 AS keep_alive;"

--- a/prisma/migrations/20260623000000_enable_rls_security/migration.sql
+++ b/prisma/migrations/20260623000000_enable_rls_security/migration.sql
@@ -1,0 +1,22 @@
+-- Enable Row Level Security (RLS) on all public tables.
+--
+-- Why: Supabase exposes the `public` schema through PostgREST (anon API key).
+-- With RLS disabled, anyone holding the anon key could read/write every row
+-- directly, bypassing the Express backend. The Security Advisor flags this.
+--
+-- Safe for this project: the backend connects via Prisma using the table-owner
+-- role (`postgres`) in DATABASE_URL. Table owners BYPASS RLS unless FORCE is
+-- used, so Prisma queries keep working. We intentionally add NO policies and do
+-- NOT use FORCE -- this simply closes the anon/PostgREST surface.
+
+ALTER TABLE public."User" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public."Profile" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public."BankAccount" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public."EWallet" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public."Client" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public."Product" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public."Invoice" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public."InvoiceItem" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public."Payment" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public."RecurringInvoice" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public."RecurringInvoiceItem" ENABLE ROW LEVEL SECURITY;


### PR DESCRIPTION
- Enable RLS on all public tables (migration; already applied to DB) to resolve Supabase Security Advisor errors.
- Add daily GitHub Actions ping to prevent free-tier auto-pause.