### PR TITLE
fix: clean up tsconfig (remove unused baseUrl/paths, add rootDir)

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "ignoreDeprecations": "5.0",
     "target": "ES2016",
     "module": "commonjs",
     "strict": true,
@@ -8,17 +7,14 @@
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "outDir": "./dist",
-    "baseUrl": ".",
+    "rootDir": "./src",
     "typeRoots": [
       "./node_modules/@types",
       "./src/types"
-    ],
-    "paths": {
-      "*": ["node_modules/*", "src/types/*"]
-    }
+    ]
   },
   "include": [
-    "./src/**/*",
+    "./src/**/*"
   ],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
Removes the wildcard `paths` mapping that broke @types resolution for express/jsonwebtoken/bcrypt in the editor, drops deprecated baseUrl, and sets rootDir explicitly. Build and type-check verified clean.